### PR TITLE
Enable VAAPI hardware acceleration for ZoneMinder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -173,6 +173,8 @@ RUN apt-get update \
         liblwp-protocol-https-perl \
         # Shapely/GEOS for ZMES object detection hooks
         libgeos-dev \
+        # VAAPI hardware acceleration
+        intel-media-va-driver \
         # Shared libraries needed by ZM binaries
         libjpeg62-turbo \
         libpcre2-8-0 \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,11 @@ else
     rm -f /etc/mysql/mariadb.conf.d/99-skip-ssl.cnf
 fi
 
+# Ensure render group (GID 992) exists and www-data is a member, for VAAPI hardware acceleration
+echo "Setting up render group for VAAPI hardware acceleration"
+getent group render > /dev/null 2>&1 || groupadd -g 992 render
+id -nG www-data | grep -qw render || usermod -aG render www-data
+
 echo "Interpolating ZM_DB_* env vars into /etc/zm/zm.conf"
 sed  -i "s|ZM_DB_HOST=.*|ZM_DB_HOST=${ZM_DB_HOST}|" /etc/zm/zm.conf
 sed  -i "s|ZM_DB_NAME=.*|ZM_DB_NAME=${ZM_DB_NAME}|" /etc/zm/zm.conf


### PR DESCRIPTION
## Summary
- Install `intel-media-va-driver` package in the runtime stage for Intel VAAPI support
- Idempotently create a `render` group (GID 992) and add `www-data` to it in the entrypoint, before services start
- Guards ensure no failure if the group already exists or the user is already a member

## Test plan
- [ ] Build the Docker image successfully
- [ ] Run the container with `/dev/dri` passed through and verify `www-data` is in the `render` group
- [ ] Confirm VAAPI devices are accessible to ZoneMinder processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)