### PR TITLE
Release process improvements: GHCR-only publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,15 +9,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to Docker Hub
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          username: jantman
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker Build and Push
         uses: docker/build-push-action@v6
         with:
@@ -29,5 +32,4 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.version=${{ github.ref_name }}
             org.opencontainers.image.revision=${{ github.sha }}
-          tags: |
-            ${{ github.repository }}:${{ github.sha }}
+          outputs: type=registry,name=ghcr.io/${{ github.repository }},push-by-digest=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 # Workflow Requirements:
 #
 # 1. In repository Settings -> Actions -> General, ensure "Allow all actions and reusable workflows" is selected, and that under "Workflow permissions", "Read repository contents and packages permissions" is checked.
-# 2. On https://hub.docker.com click your username in the top right, then Account Settings, then select "Security" from the left nav menu; generate a new Access Token for this repo with read & write perms.
-# 3. In repository Settings -> Secrets and variables -> Actions, create a new Repository secret; call it ``DOCKERHUB_TOKEN`` and paste the Docker Hub access token you just created as the value.
 #
 name: Release on Tag
 on:
@@ -19,13 +17,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to Docker Hub
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          username: jantman
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Login to GHCR
-        run: echo "${{secrets.GITHUB_TOKEN}}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker Build and Push
         uses: docker/build-push-action@v6
         with:
@@ -38,14 +35,41 @@ jobs:
             org.opencontainers.image.version=${{ github.ref_name }}
             org.opencontainers.image.revision=${{ github.sha }}
           tags: |
-            ${{ github.repository }}:${{ github.ref_name }}
-            ${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
             ghcr.io/${{ github.repository }}:latest
+      - name: Get previous tag
+        id: prev_tag
+        run: |
+          PREV_TAG=$(git tag --sort=-creatordate | head -n 2 | tail -n 1)
+          echo "prev_tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
+      - name: Generate release body
+        id: release_body
+        run: |
+          TAG="${{ github.ref_name }}"
+          PREV_TAG="${{ steps.prev_tag.outputs.prev_tag }}"
+          {
+            echo "body<<RELEASE_BODY_EOF"
+            echo "## Docker Images"
+            echo ""
+            echo "\`\`\`"
+            echo "docker pull ghcr.io/${{ github.repository }}:${TAG}"
+            echo "docker pull ghcr.io/${{ github.repository }}:latest"
+            echo "\`\`\`"
+            echo ""
+            echo "## Changelog"
+            echo ""
+            if [ -n "$PREV_TAG" ] && [ "$PREV_TAG" != "$TAG" ]; then
+              git log --pretty=format:"- %s (%h)" "${PREV_TAG}..HEAD"
+            else
+              echo "Initial release."
+            fi
+            echo ""
+            echo "RELEASE_BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           name: Release ${{ github.ref_name }}
-          body: Release ${{ github.ref_name }}
+          body: ${{ steps.release_body.outputs.body }}
           draft: false
           prerelease: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,8 @@ There is no automated test suite. Verification is manual: build the image and ru
 
 ## CI/CD
 
-- **Push to main / PR to main** (`build.yml`): Builds image, pushes to Docker Hub tagged with commit SHA.
-- **Git tag push** (`release.yml`): Builds and pushes to both Docker Hub and GHCR with version tag + `latest`, creates a GitHub Release.
+- **Push to main / PR to main** (`build.yml`): Builds image, pushes to GHCR as an untagged package.
+- **Git tag push** (`release.yml`): Builds and pushes to GHCR with version tag + `latest`, creates a GitHub Release with image info and changelog.
 - All GitHub Actions checks must pass before merging PRs.
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The image includes [go2rtc](https://github.com/AlexxIT/go2rtc) v1.9.14 for moder
 
 ## Development
 
-1. Cut a branch and make some changes. Ideally build the Docker image locally to ensure it builds. Cut a PR. That will trigger a build, and will push the resulting image to Docker Hub with a tag of the commit SHA.
+1. Cut a branch and make some changes. Ideally build the Docker image locally to ensure it builds. Cut a PR. That will trigger a build, and will push the resulting image to GHCR as an untagged package.
 2. Test that image.
 3. When the image is verified to work, merge the PR to `main`.
-4. Add a new release version tag for main and push it; that will trigger a full release build and release the new version.
+4. Add a new release version tag for main and push it; that will trigger a full release build, push versioned and `latest` tags to GHCR, and create a GitHub Release with image info and changelog.

--- a/docs/features/completed/release-process-improvements.md
+++ b/docs/features/completed/release-process-improvements.md
@@ -1,0 +1,52 @@
+# Release Process Improvements
+
+You must read, understand, and follow all instructions in `./README.md` when planning and implementing this feature.
+
+## Overview
+
+Implements GitHub Issue #12: Release process improvements. Three changes:
+
+1. Include docker image names/tags and changelog in release notes
+2. Stop pushing to Docker Hub (and logging in there); push to GHCR only
+3. Push `build` (pre-release / PR build) images to GHCR but do not tag them so they show up only as untagged in GitHub Packages
+
+## Implementation Plan
+
+### Milestone 1: Workflow Changes
+
+**Task 1.1: Remove Docker Hub from release.yml**
+- Remove the Docker Hub login step
+- Remove Docker Hub image tags (`${{ github.repository }}:${{ github.ref_name }}` and `${{ github.repository }}:latest`)
+- Keep only GHCR tags
+- Update the header comments to remove Docker Hub setup instructions
+
+**Task 1.2: Remove Docker Hub from build.yml, push to GHCR as untagged**
+- Remove Docker Hub login step
+- Add GHCR login using `GITHUB_TOKEN`
+- Add `packages: write` permission
+- Push to GHCR without a tag. To achieve "untagged" images in GitHub Packages, we push using the digest only — by building and pushing with `push-by-digest: true` and `tags: ""` in `docker/build-push-action`. This builds and pushes the image to GHCR but without any tag, so it appears as an untagged package.
+
+**Task 1.3: Add changelog and image info to release notes**
+- In `release.yml`, generate release notes body that includes:
+  - The GHCR image names/tags being published
+  - A changelog generated from commits since the previous tag (using `git log`)
+- Use the `softprops/action-gh-release` body parameter with the generated content
+
+### Milestone 2: Acceptance Criteria
+
+**Task 2.1: Update documentation**
+- Update `README.md` and `CLAUDE.md` CI/CD sections to reflect GHCR-only publishing
+- Remove any Docker Hub references
+
+**Task 2.2: Move feature doc to completed**
+- Move this file to `docs/features/completed/`
+
+## Progress
+
+- [x] Milestone 1: Workflow Changes
+  - [x] Task 1.1: Remove Docker Hub from release.yml
+  - [x] Task 1.2: Remove Docker Hub from build.yml, push to GHCR as untagged
+  - [x] Task 1.3: Add changelog and image info to release notes
+- [x] Milestone 2: Acceptance Criteria
+  - [x] Task 2.1: Update documentation
+  - [ ] Task 2.2: Move feature doc to completed


### PR DESCRIPTION
## Summary

- Remove Docker Hub login and publishing from both `build.yml` and `release.yml`; push all images to GHCR only
- Pre-release/PR build images are pushed as untagged packages (via `push-by-digest`) so they don't clutter GitHub Packages with named tags
- Release notes now include Docker pull commands and a changelog generated from commits since the previous tag
- Updated `README.md` and `CLAUDE.md` CI/CD documentation

Closes #12

## Test plan

- [ ] Verify the build workflow runs successfully on this PR (image pushed to GHCR as untagged)
- [ ] After merge, verify a tag push produces a release with image info and changelog in the notes
- [ ] Confirm no Docker Hub references remain in workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)