### PR TITLE
Fix go2rtc config overwrite that breaks browser WebRTC streaming

### DIFF
--- a/content/go2rtc-run
+++ b/content/go2rtc-run
@@ -2,7 +2,20 @@
 # ==============================================================================
 # go2rtc
 # Runs go2rtc streaming server for WebRTC/MSE/HLS live streaming
+#
+# Uses two config files per go2rtc's intended design
+# (see https://github.com/ZoneMinder/zoneminder/blob/fd8adee68cd2cdb746eb905da03ed24191f999a6/misc/zoneminder.gortc.service):
+#   1. /var/run/zm/go2rtc-streams.yaml - writable, for stream registrations
+#      (go2rtc's PatchConfig overwrites this when ZM registers streams via PUT /api/streams;
+#       see https://github.com/AlexxIT/go2rtc/blob/dc1685e9cf7a8c349181f20a1b4a44825ed394c5/internal/app/config.go)
+#   2. /etc/zm/go2rtc.yaml - read-only permanent settings (api, rtsp, webrtc)
+#      (listed second so its settings take precedence and are never overwritten)
 # ==============================================================================
 
 echo "Starting go2rtc..."
-exec /usr/local/bin/go2rtc -c /etc/zm/go2rtc.yaml
+
+# Ensure the writable streams config exists (go2rtc needs it on first start)
+mkdir -p /var/run/zm
+touch /var/run/zm/go2rtc-streams.yaml
+
+exec /usr/local/bin/go2rtc -c /var/run/zm/go2rtc-streams.yaml -c /etc/zm/go2rtc.yaml


### PR DESCRIPTION
## Summary

- go2rtc intermittently loses its `api.origin` setting, causing browser WebSocket connections to get HTTP 403 and breaking all WebRTC streaming in the ZM web UI
- Root cause: go2rtc's `PatchConfig` writes stream registrations back to its first `-c` config file, and with a single config file the permanent `api`/`rtsp`/`webrtc` settings can be clobbered
- This is a known design consideration [documented in ZoneMinder's own systemd service file](https://github.com/ZoneMinder/zoneminder/blob/fd8adee68cd2cdb746eb905da03ed24191f999a6/misc/zoneminder.gortc.service): *"This first entry will get overwritten when you add streams and can get wiped out. Place the permanent config in the second file"*
- Fix: use two `-c` config files — a writable one for streams (first, written to by [go2rtc's PatchConfig](https://github.com/AlexxIT/go2rtc/blob/dc1685e9cf7a8c349181f20a1b4a44825ed394c5/internal/app/config.go)) and the existing read-only one for permanent settings (second, never overwritten)

## Test plan

- [ ] Build image and deploy to ZM host
- [ ] Verify go2rtc streaming works in browser immediately after deploy
- [ ] Verify `/api/config` includes both streams and permanent settings
- [ ] Monitor with `go2rtc_monitor.sh` over several days to confirm the config no longer breaks
- [ ] Verify streams are persisted in `/var/run/zm/go2rtc-streams.yaml` after ZM registers them

🤖 Generated with [Claude Code](https://claude.com/claude-code)